### PR TITLE
Get solr parameters from config instead of hard coded

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Example:
     "solr_service_url": "http://localhost:8983/solr/gdi/select",
     "word_split_re": "[\\s,.:;\"]+",
     "search_result_limit": 50,
-    "db_url": "postgresql:///?service=qwc_geodb"
+    "db_url": "postgresql:///?service=qwc_geodb",
+    "solr_parameters": "omitHeader=true&facet=true&facet.field=facet&sort=score desc,sort asc"
   },
   "resources": {
     "facets": [
@@ -107,12 +108,13 @@ Example:
 
 Config options in the config file can be overridden by equivalent uppercase environment variables.
 
-| Variable                | Description                                 | Default value                           |
-|-------------------------|---------------------------------------------|-----------------------------------------|
-| SOLR_SERVICE_URL        | SOLR service URL                            | `http://localhost:8983/solr/gdi/select` |
-| WORD_SPLIT_RE           | Word split Regex                            | `[\s,.:;"]+`                            |
-| SEARCH_RESULT_LIMIT     | Result count limit per search               | `50`                                    |
-| DB_URL                  | DB connection for search geometries view    |                                         |
+| Variable            | Description                              | Default value                                                           |
+|---------------------|------------------------------------------|-------------------------------------------------------------------------|
+| SOLR_SERVICE_URL    | SOLR service URL                         | `http://localhost:8983/solr/gdi/select`                                 |
+| WORD_SPLIT_RE       | Word split Regex                         | `[\s,.:;"]+`                                                            |
+| SEARCH_RESULT_LIMIT | Result count limit per search            | `50`                                                                    |
+| DB_URL              | DB connection for search geometries view |                                                                         |
+| SOLR_PARAMETERS     | URL parameters for solr search           | `omitHeader=true&facet=true&facet.field=facet&sort=score desc,sort asc` |
 
 
 Solr Setup

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Example:
     "solr_service_url": "http://localhost:8983/solr/gdi/select",
     "word_split_re": "[\\s,.:;\"]+",
     "search_result_limit": 50,
-    "db_url": "postgresql:///?service=qwc_geodb",
-    "solr_parameters": "omitHeader=true&facet=true&facet.field=facet&sort=score desc,sort asc"
+    "search_result_sort": "score desc, sort asc",
+    "db_url": "postgresql:///?service=qwc_geodb"
   },
   "resources": {
     "facets": [
@@ -108,13 +108,14 @@ Example:
 
 Config options in the config file can be overridden by equivalent uppercase environment variables.
 
-| Variable            | Description                              | Default value                                                           |
-|---------------------|------------------------------------------|-------------------------------------------------------------------------|
-| SOLR_SERVICE_URL    | SOLR service URL                         | `http://localhost:8983/solr/gdi/select`                                 |
-| WORD_SPLIT_RE       | Word split Regex                         | `[\s,.:;"]+`                                                            |
-| SEARCH_RESULT_LIMIT | Result count limit per search            | `50`                                                                    |
-| DB_URL              | DB connection for search geometries view |                                                                         |
-| SOLR_PARAMETERS     | URL parameters for solr search           | `omitHeader=true&facet=true&facet.field=facet&sort=score desc,sort asc` |
+| Variable            | Description                              | Default value                           |
+|---------------------|------------------------------------------|-----------------------------------------|
+| SOLR_SERVICE_URL    | SOLR service URL                         | `http://localhost:8983/solr/gdi/select` |
+| WORD_SPLIT_RE       | Word split Regex                         | `[\s,.:;"]+`                            |
+| SEARCH_RESULT_LIMIT | Result count limit per search            | `50`                                    |
+| SEARCH_RESULT_SORT  | Sorting of search results                | `score desc, sort asc`                  |
+| DB_URL              | DB connection for search geometries view |                                         |
+
 
 
 Solr Setup

--- a/search_service.py
+++ b/search_service.py
@@ -34,6 +34,8 @@ class SolrClient:
         self.word_split_re = re.compile(
             config.get('word_split_re', r'[\s,.:;"]+')
         )
+        self.solr_parameters = config.get(
+            'solr_parameters', 'omitHeader=true&facet=true&facet.field=facet&sort=score desc,sort asc')
         self.default_search_limit = config.get('search_result_limit', 50)
 
         self.resources = self.load_resources(config)
@@ -82,8 +84,7 @@ class SolrClient:
                                    search_permissions)
         response = requests.get(
             self.solr_service_url,
-            params="omitHeader=true&facet=true&facet.field=facet&rows={}"
-                   "&sort=score desc,sort asc&{}&{}".format(limit, q, fq),
+            params=self.solr_parameters + "&rows={}&{}&{}".format(limit, q, fq),
             timeout=10)
         self.logger.debug("Sending Solr query %s" % response.url)
         self.logger.info("Search words: %s", ','.join(tokens))

--- a/search_service.py
+++ b/search_service.py
@@ -34,9 +34,8 @@ class SolrClient:
         self.word_split_re = re.compile(
             config.get('word_split_re', r'[\s,.:;"]+')
         )
-        self.solr_parameters = config.get(
-            'solr_parameters', 'omitHeader=true&facet=true&facet.field=facet&sort=score desc,sort asc')
         self.default_search_limit = config.get('search_result_limit', 50)
+        self.search_result_sort = config.get('search_result_sort', 'score desc, sort asc')
 
         self.resources = self.load_resources(config)
         self.permissions_handler = PermissionsReader(tenant, logger)
@@ -84,7 +83,8 @@ class SolrClient:
                                    search_permissions)
         response = requests.get(
             self.solr_service_url,
-            params=self.solr_parameters + "&rows={}&{}&{}".format(limit, q, fq),
+            params="omitHeader=true&facet=true&facet.field=facet&sort=" +
+                   self.search_result_sort + "&rows={}&{}&{}".format(limit, q, fq),
             timeout=10)
         self.logger.debug("Sending Solr query %s" % response.url)
         self.logger.info("Search words: %s", ','.join(tokens))


### PR DESCRIPTION
I have the case, where search results of addresses including characters within the house numbers like "1a" are not sorted like expected like "1, 1a, 2, ..." but instead like "1, 2, ..., 1a". This is a result of a lower solr score of the results with included characters.
A solution would be to change the sorting of the results via the solr url parameters. Now it is hard coded with `sort=score desc,sort asc`,  but `sort=sort asc, score desc` would give expected results if the view within the data base is sorted the correct way. 
This PR gives to possibility to set the url parameters within the config.