### PR TITLE
Check permissions in search_geom_service

### DIFF
--- a/src/solr_search_service.py
+++ b/src/solr_search_service.py
@@ -290,7 +290,7 @@ class SolrClient:
         # filter by permissions
         facets = {}
         for facet in self.resources['facets']:
-            if facet in permitted_facets:
+            if facet in permitted_facets or '*' in permitted_facets:
                 facets[facet] = self.resources['facets'][facet]
 
         return facets


### PR DESCRIPTION
Permissions were ignored in search_geom_service and all solr facets accessible,

I noticed that there is some code duplication in this repository and also the handling of the search_permissions variable in solr_search_service seems to be inconsistent. There are multiple checks of type `'*' in search_permissions` but from the code it looks like the return value of `self.search_permissions` will never contain `'*'` but only the allowed facets. Hence I added the `or '*' in permitted_facets` check in the solr service as well. I think bundling the permissions logic in its own class which can be shared between the three services would be beneficial. If you are interested in such a refactoring, I can maybe start working on a follow-up pull request.