### PR TITLE
Support solr basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Example:
   "config": {
     "search_backend": "solr",
     "solr_service_url": "http://localhost:8983/solr/gdi/select",
+    "solr_service_auth": {
+      "username": "solr",
+      "password": "SolrRocks"
+    },
     "search_result_sort": "score desc, sort asc",
     "word_split_re": "[\\s,.:;\"]+",
     "search_result_limit": 50,

--- a/schemas/qwc-search-service.json
+++ b/schemas/qwc-search-service.json
@@ -28,6 +28,20 @@
           "description": "SOLR service URL",
           "type": "string"
         },
+        "solr_service_auth": {
+          "description": "SOLR service basic authentication. Default: None",
+          "type": "object",
+          "properties": {
+            "username": {
+              "description": "Username for SOLR service authentication",
+              "type": "string"
+            },
+            "password": {
+              "description": "Password for SOLR service authentication",
+              "type": "string"
+            }
+          }
+        },
         "search_result_sort": {
           "description": "Search result ordering for solr search results. Default: search_result_sort",
           "type": "string"

--- a/src/solr_search_service.py
+++ b/src/solr_search_service.py
@@ -33,6 +33,13 @@ class SolrClient:
 
         self.solr_service_url = config.get(
             'solr_service_url', 'http://localhost:8983/solr/gdi/select')
+
+        self.solr_service_auth = config.get('solr_service_auth', None)
+
+        if self.solr_service_auth:
+            self.solr_service_auth = (self.solr_service_auth.get('username'),
+                                      self.solr_service_auth.get('password'))
+
         self.word_split_re = re.compile(
             config.get('word_split_re', r'[\s,.:;"]+')
         )
@@ -85,6 +92,7 @@ class SolrClient:
             self.solr_service_url,
             params="omitHeader=true&facet=true&facet.field=facet&sort=" +
                    self.search_result_sort + "&rows={}&{}&{}".format(limit, q, fq),
+            auth=self.solr_service_auth,
             timeout=10)
         self.logger.debug("Sending Solr query %s" % response.url)
         self.logger.info("Search words: %s", ','.join(tokens))


### PR DESCRIPTION
This pull request introduces an optional config parameter `solr_service_auth` which can be filled with an object containing username and password of a Solr service that is protected by the `solr.BasicAuthPlugin`.